### PR TITLE
公式noteリンクの追加とURLのクリーン化

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -58,7 +58,7 @@
 <!-- Header -->
 <header class="bg-white border-b py-4 fixed top-0 left-0 right-0 z-50">
     <div class="container mx-auto flex items-center justify-between px-4">
-        <a href="index.html" class="flex items-center">
+        <a href="/" class="flex items-center">
             <img src="assets/images/komekaigi_symbol.svg" alt="KomeKaigi Logo" class="h-8 md:h-10 mr-2 md:mr-3"/>
             <h1 class="text-xl md:text-2xl font-bold text-[#fabe00]">KomeKaigi 2025</h1>
         </a>
@@ -66,9 +66,11 @@
         <!-- Desktop Navigation -->
         <nav class="hidden md:block">
             <ul class="flex space-x-6">
-                <li><a href="index.html" class="hover:text-[#fabe00] transition-colors">トップ</a></li>
+                <li><a href="/" class="hover:text-[#fabe00] transition-colors">トップ</a></li>
                 <li><a href="https://x.com/komekaigi" target="_blank"
                        class="hover:text-[#fabe00] transition-colors">公式X</a></li>
+                <li><a href="https://note.com/komekaigi/m/mf56a6e60a550" target="_blank"
+                       class="hover:text-[#fabe00] transition-colors">公式note</a></li>
             </ul>
         </nav>
         
@@ -83,9 +85,11 @@
     <!-- Mobile Navigation Menu -->
     <nav id="mobile-menu" class="md:hidden hidden bg-white border-t">
         <ul class="flex flex-col py-4">
-            <li><a href="index.html" class="block px-4 py-3 hover:bg-[#fabe00]/10 transition-colors text-center">トップ</a></li>
+            <li><a href="/" class="block px-4 py-3 hover:bg-[#fabe00]/10 transition-colors text-center">トップ</a></li>
             <li><a href="https://x.com/komekaigi" target="_blank"
                    class="block px-4 py-3 hover:bg-[#fabe00]/10 transition-colors text-center">公式X</a></li>
+            <li><a href="https://note.com/komekaigi/m/mf56a6e60a550" target="_blank"
+                   class="block px-4 py-3 hover:bg-[#fabe00]/10 transition-colors text-center">公式note</a></li>
         </ul>
     </nav>
 </header>

--- a/docs/index.html
+++ b/docs/index.html
@@ -184,11 +184,13 @@
         <!-- Desktop Navigation -->
         <nav class="hidden md:block">
             <ul class="flex space-x-6">
-                <li><a href="about.html" class="hover:text-[#fabe00] transition-colors">開催趣旨</a></li>
+                <li><a href="/about" class="hover:text-[#fabe00] transition-colors">開催趣旨</a></li>
                 <li><a href="#overview" class="hover:text-[#fabe00] transition-colors">概要</a></li>
                 <li><a href="#access" class="hover:text-[#fabe00] transition-colors">アクセス</a></li>
                 <li><a href="https://x.com/komekaigi" target="_blank"
                        class="hover:text-[#fabe00] transition-colors">公式X</a></li>
+                <li><a href="https://note.com/komekaigi/m/mf56a6e60a550" target="_blank"
+                       class="hover:text-[#fabe00] transition-colors">公式note</a></li>
             </ul>
         </nav>
         
@@ -203,11 +205,13 @@
     <!-- Mobile Navigation Menu -->
     <nav id="mobile-menu" class="md:hidden hidden bg-white/95 backdrop-blur border-t">
         <ul class="flex flex-col py-4">
-            <li><a href="about.html" class="block px-4 py-3 hover:bg-[#fabe00]/10 transition-colors text-center">開催趣旨</a></li>
+            <li><a href="/about" class="block px-4 py-3 hover:bg-[#fabe00]/10 transition-colors text-center">開催趣旨</a></li>
             <li><a href="#overview" class="block px-4 py-3 hover:bg-[#fabe00]/10 transition-colors text-center">概要</a></li>
             <li><a href="#access" class="block px-4 py-3 hover:bg-[#fabe00]/10 transition-colors text-center">アクセス</a></li>
             <li><a href="https://x.com/komekaigi" target="_blank"
                    class="block px-4 py-3 hover:bg-[#fabe00]/10 transition-colors text-center">公式X</a></li>
+            <li><a href="https://note.com/komekaigi/m/mf56a6e60a550" target="_blank"
+                   class="block px-4 py-3 hover:bg-[#fabe00]/10 transition-colors text-center">公式note</a></li>
         </ul>
     </nav>
 </header>


### PR DESCRIPTION
## Summary
- ヘッダーナビゲーションに公式noteへのリンクを追加しました
- URLから.html拡張子を削除し、よりクリーンなURLパス構造にしました
- デスクトップとモバイルの両方のナビゲーションメニューを更新しました

## Changes
### 公式noteリンクの追加
- 両ページのヘッダーメニューに「公式note」リンクを追加
- URL: https://note.com/komekaigi/m/mf56a6e60a550

### URLのクリーン化
- `/about.html` → `/about`
- `/index.html` → `/`
- より直感的でSEOフレンドリーなURL構造に変更

## Test plan
- [ ] 公式noteリンクが正しく動作することを確認
- [ ] ナビゲーションリンクが適切に機能することを確認
- [ ] モバイル表示でもリンクが正しく表示されることを確認

## Notes
ローカル環境で直接HTMLファイルを開いた場合、クリーンURLはパスの問題でエラーになる可能性があります。本番環境やローカルサーバーでは正常に動作します。

🤖 Generated with [Claude Code](https://claude.ai/code)